### PR TITLE
Update mix ver (forgot to update on DIVO_DOWN pr)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,8 @@
+## Description
+
+- High level overview of changes
+- ...
+
+## Reminders:
+
+- [ ] Did you update the version in `mix.exs`?

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ end
 ```
 
 The docs can be found at [https://hexdocs.pm/divo](https://hexdocs.pm/divo).
+New versions are published with actions upon github release.
 
 ## Configuration
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Divo.MixProject do
   def project do
     [
       app: :divo,
-      version: "1.3.1",
+      version: "1.3.2",
       elixir: "~> 1.8",
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
- ups mix version [(forgot to in the last pr)](https://github.com/UrbanOS-Public/divo/pull/52)
  - add pr template to remind contributors of this
- readme explains that deployments happen on release